### PR TITLE
feat: create screen jobs recruiter

### DIFF
--- a/src/app/candidato/(root)/layout.jsx
+++ b/src/app/candidato/(root)/layout.jsx
@@ -36,11 +36,11 @@ const Layout = ({ children, variant = 'default' }) => {
   return (
     <div className={twMerge('w-full h-screen flex flex-col md:flex-row', style.background[theme])}>
       <MenuDesk className="hidden md:flex" links={links} />
-      <div className="w-full grow overflow-auto flex flex-col px-7">
+      <div className="w-full grow overflow-auto flex flex-col px-5">
         <AccessibilityNavbar className="w-full flex items-center justify-end py-4" />
         {children}
       </div>
-      <MenuMobile links={links} />
+      <MenuMobile links={links} className="px-4" />
     </div>
   );
 };

--- a/src/app/candidato/(root)/vagas/page.jsx
+++ b/src/app/candidato/(root)/vagas/page.jsx
@@ -49,10 +49,11 @@ const Jobs = ({ variant = 'default' }) => {
             <InputSearch
               type="text"
               id="search"
+              size={20}
               placeholder="pesquisar por vagas"
               className="w-full"
             />
-            <Filter />
+            <Filter size={40} />
           </div>
           <p
             className={twMerge(

--- a/src/app/recrutador/(root)/layout.jsx
+++ b/src/app/recrutador/(root)/layout.jsx
@@ -1,0 +1,50 @@
+'use client';
+import {
+  LuBriefcase,
+  LuHourglass,
+  LuLayoutDashboard,
+  LuCalendarDays,
+  LuSettings,
+} from 'react-icons/lu';
+import { RiUserSearchLine } from 'react-icons/ri';
+import { twMerge } from 'tailwind-merge';
+import { AccessibilityNavbar } from '@/components/shared/AccessibilityNavbar';
+import { MenuDesk, MenuMobile } from '@/components/shared/MenuApp';
+import { themes, useTheme } from '@/contexts/ThemeContext';
+
+const links = [
+  { href: '/recrutador/dashboard', icon: <LuLayoutDashboard size={36} /> },
+  { href: '/recrutador/vagas', icon: <LuBriefcase size={36} /> },
+  { href: '/recrutador/buscar-candidato', icon: <RiUserSearchLine size={36} /> },
+  { href: '/recrutador/processo-em-andamento', icon: <LuHourglass size={36} /> },
+  { href: '/recrutador/programacao-da-semana', icon: <LuCalendarDays size={36} /> },
+  { href: '/recrutador/configuracoes', icon: <LuSettings size={36} /> },
+];
+
+const styles = {
+  default: {
+    background: {
+      [themes.DEFAULT]: 'bg-neutral-10',
+      [themes.DARK]: 'bg-neutral-0',
+      [themes.LIGHT]: 'bg-neutral-90',
+    },
+  },
+};
+
+const Layout = ({ children, variant = 'default' }) => {
+  const { theme } = useTheme();
+  const style = styles[variant];
+
+  return (
+    <div className={twMerge('w-full h-screen flex flex-col md:flex-row', style.background[theme])}>
+      <MenuDesk className="hidden md:flex" links={links} />
+      <div className="w-full grow overflow-auto flex flex-col px-7">
+        <AccessibilityNavbar className="w-full flex items-center justify-end py-4" />
+        {children}
+      </div>
+      <MenuMobile links={links} />
+    </div>
+  );
+};
+
+export default Layout;

--- a/src/app/recrutador/(root)/layout.jsx
+++ b/src/app/recrutador/(root)/layout.jsx
@@ -38,11 +38,11 @@ const Layout = ({ children, variant = 'default' }) => {
   return (
     <div className={twMerge('w-full h-screen flex flex-col md:flex-row', style.background[theme])}>
       <MenuDesk className="hidden md:flex" links={links} />
-      <div className="w-full grow overflow-auto flex flex-col px-7">
+      <div className="w-full grow overflow-auto flex flex-col lg:px-7 px-5">
         <AccessibilityNavbar className="w-full flex items-center justify-end py-4" />
         {children}
       </div>
-      <MenuMobile links={links} />
+      <MenuMobile links={links} className="px-3" />
     </div>
   );
 };

--- a/src/app/recrutador/(root)/vagas/JobTable.jsx
+++ b/src/app/recrutador/(root)/vagas/JobTable.jsx
@@ -1,0 +1,61 @@
+'use client';
+import { useState } from 'react';
+import { JobTableContext } from './JobTableContext';
+import { ButtonSelectAll } from '@/components/shared/ButtonSelectAll';
+import { Filter } from '@/components/shared/Filter';
+import { Table } from '@/components/shared/Table';
+import { commons } from '@/locales';
+
+const JobTable = ({ jobs }) => {
+  const [checked, setChecked] = useState(false);
+  return (
+    <Table.Root>
+      <Table.Row className={'justify-between lg:pr-3 lg:pl-5'}>
+        <Table.Header className={'w-[70px]'}>
+          <ButtonSelectAll onChange={setChecked} />
+        </Table.Header>
+        <Table.Header className={'lg:w-[calc(100% / 6)]'}>
+          {commons.tableJobs.jobs}
+          <Filter size={20} variant="inverse" />
+        </Table.Header>
+        <Table.Header className={'lg:w-[calc(100% / 6)]'}>
+          {commons.tableJobs.sector}
+          <Filter size={20} variant="inverse" />
+        </Table.Header>
+        <Table.Header
+          className={'hidden lg:flex  lg:w-[calc(100% / 6)] justify-center text-center'}
+        >
+          {commons.tableJobs.numberJobs}
+          <Filter size={20} variant="inverse" />
+        </Table.Header>
+        <Table.Header className={'hidden lg:flex lg:w-[calc(100% / 6)] justify-center text-center'}>
+          {commons.tableJobs.initialDate}
+          <Filter size={20} variant="inverse" />
+        </Table.Header>
+        <Table.Header className={'hidden lg:flex lg:w-[calc(100% / 6)] justify-center text-center'}>
+          {commons.tableJobs.finalDate}
+          <Filter size={20} variant="inverse" />
+        </Table.Header>
+        <Table.Header className={'justify-center text-center'}>
+          {commons.tableJobs.details}
+        </Table.Header>
+      </Table.Row>
+      {jobs.map((job, index) => {
+        return (
+          <JobTableContext
+            // alterar key para id quando integrar com backend
+            key={index}
+            job={job.job}
+            sector={job.sector}
+            quantity={job.quantity}
+            publishedAt={job.publishedAt}
+            expiresAt={job.expiresAt}
+            checkAll={checked}
+          />
+        );
+      })}
+    </Table.Root>
+  );
+};
+
+export { JobTable };

--- a/src/app/recrutador/(root)/vagas/JobTableContext.jsx
+++ b/src/app/recrutador/(root)/vagas/JobTableContext.jsx
@@ -1,0 +1,81 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { MdFiberManualRecord } from 'react-icons/md';
+import { twMerge } from 'tailwind-merge';
+import { Table } from '@/components/shared/Table';
+import { themes, useTheme } from '@/contexts/ThemeContext';
+
+const styles = {
+  default: {
+    background: {
+      [themes.DEFAULT]: 'bg-neutral-0',
+      [themes.DARK]: 'border-2 border-neutral-90 bg-neutral-0',
+      [themes.LIGHT]: 'bg-neutral-0',
+    },
+    details: {
+      [themes.DEFAULT]: 'text-primary-90',
+      [themes.DARK]: 'text-neutral-90',
+      [themes.LIGHT]: 'text-neutral-90',
+    },
+    checkbox: {
+      [themes.DEFAULT]: 'accent-primary-90',
+      [themes.DARK]: 'accent-neutral-90',
+      [themes.LIGHT]: 'accent-neutral-90',
+    },
+  },
+};
+
+const JobTableContext = ({ job, expiresAt, publishedAt, quantity, sector, checkAll }) => {
+  const { theme } = useTheme();
+  const style = styles['default'];
+  const [checked, setChecked] = useState(false);
+
+  useEffect(() => {
+    setChecked(checkAll);
+  }, [checkAll]);
+
+  return (
+    <>
+      <Table.Row
+        className={twMerge(
+          'flex justify-between rounded-md mt-2 py-2 lg:px-6',
+          style.background[theme],
+        )}
+      >
+        <Table.Cells className="w-fit justify-center lg:flex items-center">
+          <input
+            type="checkbox"
+            name=""
+            id="checkbox"
+            checked={checked}
+            onClick={() => setChecked(!checked)}
+            className={twMerge('cursor-pointer', style.checkbox[theme])}
+          />
+        </Table.Cells>
+        <Table.Cells className="w-[calc(100% / 2] lg:w-[calc(100% / 6] lg:flex">{job}</Table.Cells>
+        <Table.Cells className="w-[calc(100% / 2] lg:w-[calc(100% / 6] lg:flex ">
+          {sector}
+        </Table.Cells>
+        <Table.Cells className="w-[calc(100% / 6] hidden lg:flex justify-center text-center">
+          {quantity}
+        </Table.Cells>
+        <Table.Cells className="w-[calc(100% / 6] hidden  justify-center lg:flex text-center ">
+          {publishedAt}
+        </Table.Cells>
+        <Table.Cells className="w-[calc(100% / 6] hidden lg:flex justify-center text-center">
+          {expiresAt}
+        </Table.Cells>
+
+        <Table.Cells className={'flex'}>
+          <button className="w-full flex justify-center cursor-pointer">
+            <MdFiberManualRecord size={12} className={style.details[theme]} />
+            <MdFiberManualRecord size={12} className={style.details[theme]} />
+            <MdFiberManualRecord size={12} className={style.details[theme]} />
+          </button>
+        </Table.Cells>
+      </Table.Row>
+    </>
+  );
+};
+
+export { JobTableContext };

--- a/src/app/recrutador/(root)/vagas/page.jsx
+++ b/src/app/recrutador/(root)/vagas/page.jsx
@@ -1,0 +1,81 @@
+import { Filter } from '@/components/shared/Filter';
+import { InputSearch } from '@/components/shared/InputSearch';
+import { Title } from '@/components/shared/Title';
+import { recruiter } from '@/locales';
+import { MdAddBox, MdOutlineSelectAll, MdDeleteSweep, MdFiberManualRecord } from 'react-icons/md';
+
+const Jobs = ({}) => {
+  return (
+    <>
+      <Title className="text-3xl" variant="inverse">
+        {recruiter.jobs.title}
+      </Title>
+      <p className="mt-2"> {recruiter.jobs.description}</p>
+
+      <div className="flex mt-4 mb-7 w-1/2">
+        <InputSearch variant="inverse" size={18} />
+        <div className="ml-4 gap-3 flex">
+          <button>
+            <MdAddBox size={30} />
+          </button>
+          <button>
+            <MdDeleteSweep size={30} />
+          </button>
+        </div>
+      </div>
+
+      <div className="w-full">
+        <table className="w-full">
+          <tr className="w-full flex justify-between">
+            <th align="center" className="w-96 justify-center flex ">
+              <button>
+                <MdOutlineSelectAll size={20} />
+              </button>
+            </th>
+            <th className="w-full flex mr-3 items-center">
+              Vagas
+              <Filter size={20} />
+            </th>
+            <th className="w-full flex items-center">
+              Setor <Filter size={20} />
+            </th>
+            <th className="w-1/2 flex justify-center items-center mr-3 ">
+              N° de vagas <Filter size={20} />
+            </th>
+            <th className="w-full flex justify-center items-center mr-3 ">
+              Data Inicial <Filter size={20} />
+            </th>
+            <th className="w-full flex  justify-center items-center mr-3 ">
+              Data Final <Filter size={20} />
+            </th>
+            <th className="w-1/2 flex justify-center items-center">
+              Detalhes
+              <Filter size={20} />
+            </th>
+          </tr>
+          <tr className="bg-neutral-0 w-full flex justify-between mt-2">
+            <td className="w-96 justify-center flex  items-center">
+              <input type="checkbox" name="" id="" />
+            </td>
+            <td className="w-full flex justify-start items-center mr-3">Desenvolvedor Front-end</td>
+            <td className="w-full flex justify-start items-center mr-3">
+              TecnologiaTecnologia Tecnologia
+            </td>
+            <td className="w-1/2 flex justify-center items-center mr-3">3</td>
+            <td className="w-full flex justify-center items-center mr-3">15/12/2023</td>
+            <td className="w-full flex justify-center items-center mr-3">20/12/2023</td>
+            <td className="w-1/2 flex justify-center items-center">
+              <button className=" flex justify-end">
+                <MdFiberManualRecord size={12} />
+                <MdFiberManualRecord size={12} />
+                <MdFiberManualRecord size={12} />
+              </button>
+            </td>
+          </tr>
+        </table>
+      </div>
+    </>
+  );
+};
+
+export default Jobs;

--- a/src/app/recrutador/(root)/vagas/page.jsx
+++ b/src/app/recrutador/(root)/vagas/page.jsx
@@ -1,79 +1,82 @@
-import { Filter } from '@/components/shared/Filter';
+'use client';
+import { MdAddBox } from 'react-icons/md';
+import { PiTrashSimpleFill } from 'react-icons/pi';
+import { twMerge } from 'tailwind-merge';
+import { JobTable } from './JobTable';
+import { ButtonIcon } from '@/components/shared/ButtonIcon';
 import { InputSearch } from '@/components/shared/InputSearch';
 import { Title } from '@/components/shared/Title';
+import { themes, useTheme } from '@/contexts/ThemeContext';
 import { recruiter } from '@/locales';
-import { MdAddBox, MdOutlineSelectAll, MdDeleteSweep, MdFiberManualRecord } from 'react-icons/md';
+
+const jobs = [
+  {
+    job: 'nanana',
+    sector: 'sadsafsdas',
+    quantity: 4,
+    publishedAt: '15/12/2023',
+    expiresAt: '15/12/2023',
+  },
+  {
+    job: 'nanana',
+    sector: 'sadsafsdas',
+    quantity: 4,
+    publishedAt: '15/12/2023',
+    expiresAt: '15/12/2023',
+  },
+  {
+    job: 'nanana',
+    sector: 'sadsafsdas',
+    quantity: 4,
+    publishedAt: '15/12/2023',
+    expiresAt: '15/12/2023',
+  },
+  {
+    job: 'nanana',
+    sector: 'sadsafsdas',
+    quantity: 4,
+    publishedAt: '15/12/2023',
+    expiresAt: '15/12/2023',
+  },
+];
+
+const styles = {
+  default: {
+    description: {
+      [themes.DEFAULT]: 'text-neutral-90',
+      [themes.DARK]: 'text-neutral-90',
+      [themes.LIGHT]: 'text-neutral-0',
+    },
+  },
+};
 
 const Jobs = ({}) => {
+  const { theme } = useTheme();
+  const style = styles['default'];
+
   return (
     <>
-      <Title className="text-3xl" variant="inverse">
-        {recruiter.jobs.title}
-      </Title>
-      <p className="mt-2"> {recruiter.jobs.description}</p>
+      <div className="w-full">
+        <Title className="text-3xl" variant="inverse">
+          {recruiter.jobs.title}
+        </Title>
+        <p className={twMerge('mt-2 w-full', style.description[theme])}>
+          {recruiter.jobs.description}
+        </p>
 
-      <div className="flex mt-4 mb-7 w-1/2">
-        <InputSearch variant="inverse" size={18} />
-        <div className="ml-4 gap-3 flex">
-          <button>
-            <MdAddBox size={30} />
-          </button>
-          <button>
-            <MdDeleteSweep size={30} />
-          </button>
+        <div className="flex mt-4 mb-7 lg:w-1/2 w-full">
+          <InputSearch variant="inverseSecundary" size={24} />
+          <div className="ml-4 gap-3 flex">
+            <ButtonIcon>
+              <MdAddBox size={30} />
+            </ButtonIcon>
+            <ButtonIcon disabled={true}>
+              <PiTrashSimpleFill size={30} />
+            </ButtonIcon>
+          </div>
         </div>
       </div>
-
-      <div className="w-full">
-        <table className="w-full">
-          <tr className="w-full flex justify-between">
-            <th align="center" className="w-96 justify-center flex ">
-              <button>
-                <MdOutlineSelectAll size={20} />
-              </button>
-            </th>
-            <th className="w-full flex mr-3 items-center">
-              Vagas
-              <Filter size={20} />
-            </th>
-            <th className="w-full flex items-center">
-              Setor <Filter size={20} />
-            </th>
-            <th className="w-1/2 flex justify-center items-center mr-3 ">
-              N° de vagas <Filter size={20} />
-            </th>
-            <th className="w-full flex justify-center items-center mr-3 ">
-              Data Inicial <Filter size={20} />
-            </th>
-            <th className="w-full flex  justify-center items-center mr-3 ">
-              Data Final <Filter size={20} />
-            </th>
-            <th className="w-1/2 flex justify-center items-center">
-              Detalhes
-              <Filter size={20} />
-            </th>
-          </tr>
-          <tr className="bg-neutral-0 w-full flex justify-between mt-2">
-            <td className="w-96 justify-center flex  items-center">
-              <input type="checkbox" name="" id="" />
-            </td>
-            <td className="w-full flex justify-start items-center mr-3">Desenvolvedor Front-end</td>
-            <td className="w-full flex justify-start items-center mr-3">
-              TecnologiaTecnologia Tecnologia
-            </td>
-            <td className="w-1/2 flex justify-center items-center mr-3">3</td>
-            <td className="w-full flex justify-center items-center mr-3">15/12/2023</td>
-            <td className="w-full flex justify-center items-center mr-3">20/12/2023</td>
-            <td className="w-1/2 flex justify-center items-center">
-              <button className=" flex justify-end">
-                <MdFiberManualRecord size={12} />
-                <MdFiberManualRecord size={12} />
-                <MdFiberManualRecord size={12} />
-              </button>
-            </td>
-          </tr>
-        </table>
-      </div>
+      <JobTable jobs={jobs} />
     </>
   );
 };

--- a/src/components/shared/Button/Button.jsx
+++ b/src/components/shared/Button/Button.jsx
@@ -1,0 +1,5 @@
+const Button = ({ children }) => {
+  <button>{children}</button>;
+};
+
+export { Button };

--- a/src/components/shared/Button/Button.jsx
+++ b/src/components/shared/Button/Button.jsx
@@ -1,5 +1,0 @@
-const Button = ({ children }) => {
-  <button>{children}</button>;
-};
-
-export { Button };

--- a/src/components/shared/Button/index.js
+++ b/src/components/shared/Button/index.js
@@ -1,1 +1,0 @@
-export * from './Button'

--- a/src/components/shared/Button/index.js
+++ b/src/components/shared/Button/index.js
@@ -1,0 +1,1 @@
+export * from './Button'

--- a/src/components/shared/ButtonDetails/ButtonDetails.jsx
+++ b/src/components/shared/ButtonDetails/ButtonDetails.jsx
@@ -1,0 +1,12 @@
+'use client';
+import { MdFiberManualRecord } from 'react-icons/md';
+
+const ButtonDetails = () => {
+  <button className="flex items-center">
+    <MdFiberManualRecord size={12} />
+    <MdFiberManualRecord size={12} />
+    <MdFiberManualRecord size={12} />
+  </button>;
+};
+
+export { ButtonDetails };

--- a/src/components/shared/ButtonDetails/index.js
+++ b/src/components/shared/ButtonDetails/index.js
@@ -1,0 +1,1 @@
+export * from './ButtonDetails'

--- a/src/components/shared/ButtonDetails/index.js
+++ b/src/components/shared/ButtonDetails/index.js
@@ -1,1 +1,1 @@
-export * from './ButtonDetails'
+export * from './ButtonDetails';

--- a/src/components/shared/ButtonIcon/ButtonIcon.jsx
+++ b/src/components/shared/ButtonIcon/ButtonIcon.jsx
@@ -1,0 +1,25 @@
+'use client';
+import { themes, useTheme } from '@/contexts/ThemeContext';
+
+const styles = {
+  default: {
+    icon: {
+      [themes.DEFAULT]: 'text-primary-90 disabled:text-neutral-60',
+      [themes.DARK]: 'text-neutral-90 disabled:text-neutral-60',
+      [themes.LIGHT]: 'text-neutral-0 disabled:text-neutral-60',
+    },
+  },
+};
+
+const ButtonIcon = ({ children, disabled = false, type }) => {
+  const { theme } = useTheme();
+  const style = styles['default'];
+
+  return (
+    <button className={style.icon[theme]} type={type} disabled={disabled}>
+      {children}
+    </button>
+  );
+};
+
+export { ButtonIcon };

--- a/src/components/shared/ButtonIcon/index.js
+++ b/src/components/shared/ButtonIcon/index.js
@@ -1,0 +1,1 @@
+export * from './ButtonIcon';

--- a/src/components/shared/ButtonSelectAll/ButtonSelectAll.jsx
+++ b/src/components/shared/ButtonSelectAll/ButtonSelectAll.jsx
@@ -1,0 +1,38 @@
+'use client';
+import { useState } from 'react';
+import { PiSelectionAllFill, PiSelectionAll } from 'react-icons/pi';
+import { twMerge } from 'tailwind-merge';
+import { themes, useTheme } from '@/contexts/ThemeContext';
+
+const styles = {
+  default: {
+    icon: {
+      [themes.DEFAULT]: 'text-primary-90',
+      [themes.DARK]: 'text-neutral-90',
+      [themes.LIGHT]: 'text-neutral-0',
+    },
+  },
+};
+
+const ButtonSelectAll = ({ onChange }) => {
+  const [checked, setChecked] = useState();
+  const { theme } = useTheme();
+  const style = styles['default'];
+  const handleCheck = () => {
+    const toggle = !checked;
+    setChecked(toggle);
+    onChange(toggle);
+  };
+
+  return (
+    <button type="button" className={twMerge('cursor-pointer', style.icon[theme])}>
+      {checked ? (
+        <PiSelectionAllFill size={24} onClick={handleCheck} />
+      ) : (
+        <PiSelectionAll size={24} onClick={handleCheck} />
+      )}
+    </button>
+  );
+};
+
+export { ButtonSelectAll };

--- a/src/components/shared/ButtonSelectAll/index.js
+++ b/src/components/shared/ButtonSelectAll/index.js
@@ -1,0 +1,1 @@
+export * from './ButtonSelectAll';

--- a/src/components/shared/Filter/Filter.jsx
+++ b/src/components/shared/Filter/Filter.jsx
@@ -11,6 +11,13 @@ const styles = {
       [themes.LIGHT]: 'text-neutral-90',
     },
   },
+  inverse: {
+    icon: {
+      [themes.DEFAULT]: 'text-primary-90',
+      [themes.DARK]: 'text-neutral-90',
+      [themes.LIGHT]: 'text-neutral-0',
+    },
+  },
 };
 
 const Filter = ({ variant = 'default', size, className }) => {

--- a/src/components/shared/Filter/Filter.jsx
+++ b/src/components/shared/Filter/Filter.jsx
@@ -1,3 +1,4 @@
+'use client';
 import { MdOutlineFilterList } from 'react-icons/md';
 import { twMerge } from 'tailwind-merge';
 import { themes, useTheme } from '@/contexts/ThemeContext';
@@ -12,13 +13,13 @@ const styles = {
   },
 };
 
-const Filter = ({ variant = 'default' }) => {
+const Filter = ({ variant = 'default', size, className }) => {
   const { theme } = useTheme();
   const style = styles[variant];
 
   return (
     <button>
-      <MdOutlineFilterList size={40} className={twMerge(' ml-2', style.icon[theme])} />
+      <MdOutlineFilterList size={size} className={twMerge(' ml-2', style.icon[theme], className)} />
     </button>
   );
 };

--- a/src/components/shared/InputSearch/InputSearch.jsx
+++ b/src/components/shared/InputSearch/InputSearch.jsx
@@ -1,3 +1,4 @@
+'use client';
 import { LuSearch } from 'react-icons/lu';
 import { twMerge } from 'tailwind-merge';
 import { themes, useTheme } from '@/contexts/ThemeContext';
@@ -21,6 +22,11 @@ const styles = {
       [themes.DARK]: 'bg-neutral-0',
       [themes.LIGHT]: 'bg-transparent border border-neutral-90',
     },
+    icon: {
+      [themes.DEFAULT]: 'text-primary-90',
+      [themes.DARK]: 'text-neutral-90',
+      [themes.LIGHT]: 'text-neutral-90',
+    },
   },
 };
 
@@ -28,6 +34,7 @@ const InputSearch = ({
   type,
   id,
   children,
+  size,
   placeholder,
   className,
   variant = 'default',
@@ -44,7 +51,7 @@ const InputSearch = ({
             'absolute inset-y-0 left-0 flex items-center pl-4 pointer-events-none',
           )}
         >
-          <LuSearch size={20} className={style.icon[theme]} />
+          <LuSearch size={size} className={(style.icon[theme], className)} />
         </div>
         <input
           type={type}

--- a/src/components/shared/InputSearch/InputSearch.jsx
+++ b/src/components/shared/InputSearch/InputSearch.jsx
@@ -1,5 +1,5 @@
 'use client';
-import { LuSearch } from 'react-icons/lu';
+import { MdSearch } from 'react-icons/md';
 import { twMerge } from 'tailwind-merge';
 import { themes, useTheme } from '@/contexts/ThemeContext';
 
@@ -21,6 +21,18 @@ const styles = {
       [themes.DEFAULT]: 'bg-neutral-0',
       [themes.DARK]: 'bg-neutral-0',
       [themes.LIGHT]: 'bg-transparent border border-neutral-90',
+    },
+    icon: {
+      [themes.DEFAULT]: 'text-primary-90',
+      [themes.DARK]: 'text-neutral-90',
+      [themes.LIGHT]: 'text-neutral-90',
+    },
+  },
+  inverseSecundary: {
+    input: {
+      [themes.DEFAULT]: 'bg-neutral-0',
+      [themes.DARK]: 'border-2 border-neutral-90 bg-neutral-0',
+      [themes.LIGHT]: 'bg-neutral-0',
     },
     icon: {
       [themes.DEFAULT]: 'text-primary-90',
@@ -51,7 +63,7 @@ const InputSearch = ({
             'absolute inset-y-0 left-0 flex items-center pl-4 pointer-events-none',
           )}
         >
-          <LuSearch size={size} className={(style.icon[theme], className)} />
+          <MdSearch size={size} className={twMerge(style.icon[theme], className)} />
         </div>
         <input
           type={type}

--- a/src/components/shared/Menu/MenuRoot.jsx
+++ b/src/components/shared/Menu/MenuRoot.jsx
@@ -16,7 +16,7 @@ const MenuRoot = ({ children, className, variant = 'default', ...props }) => {
   return (
     <nav
       className={twMerge(
-        'p-[25px] w-[100px] h-screen flex flex-col items-center',
+        'py-6 w-[100px] h-screen flex flex-col items-center',
         style[theme],
         className,
       )}

--- a/src/components/shared/MenuApp/MenuMobile.jsx
+++ b/src/components/shared/MenuApp/MenuMobile.jsx
@@ -1,12 +1,13 @@
 import { usePathname } from 'next/navigation';
+import { twMerge } from 'tailwind-merge';
 import { Menu } from '../Menu';
 
-const MenuMobile = ({ links }) => {
+const MenuMobile = ({ links, className }) => {
   const pathname = usePathname();
 
   return (
-    <Menu.Root className="w-full h-auto md:hidden ">
-      <Menu.LinkGroup className="w-full px-10 flex-row justify-between">
+    <Menu.Root className={twMerge('w-full h-auto md:hidden', className)}>
+      <Menu.LinkGroup className={twMerge('w-full flex-row justify-between', className)}>
         {links.map((link) => {
           return (
             <Menu.Link

--- a/src/components/shared/Table/TableCells.jsx
+++ b/src/components/shared/Table/TableCells.jsx
@@ -1,8 +1,9 @@
-'use client';
 import { twMerge } from 'tailwind-merge';
 
 const TableCells = ({ children, className }) => {
-  return <td className={twMerge('w-full flex items-center', className)}>{children}</td>;
+  return (
+    <td className={twMerge('w-full flex items-center text-left px-5', className)}>{children}</td>
+  );
 };
 
 export { TableCells };

--- a/src/components/shared/Table/TableCells.jsx
+++ b/src/components/shared/Table/TableCells.jsx
@@ -1,0 +1,8 @@
+'use client';
+import { twMerge } from 'tailwind-merge';
+
+const TableCells = ({ children, className }) => {
+  return <td className={twMerge('w-full flex items-center', className)}>{children}</td>;
+};
+
+export { TableCells };

--- a/src/components/shared/Table/TableHeader.jsx
+++ b/src/components/shared/Table/TableHeader.jsx
@@ -1,12 +1,26 @@
-'use client'
+'use client';
 import { twMerge } from 'tailwind-merge';
-import { Filter } from '../Filter';
+import { themes, useTheme } from '@/contexts/ThemeContext';
+
+const styles = {
+  default: {
+    text: {
+      [themes.DEFAULT]: 'text-neutral-90',
+      [themes.DARK]: 'text-neutral-90',
+      [themes.LIGHT]: 'text-neutral-0',
+    },
+  },
+};
 
 const TableHeader = ({ children, className }) => {
+  const { theme } = useTheme();
+  const style = styles['default'];
+
   return (
-    <th className={twMerge('w-full flex items-center', className)}>
+    <th
+      className={twMerge('w-full flex items-center text-left px-4', style.text[theme], className)}
+    >
       {children}
-      <Filter size={20} />
     </th>
   );
 };

--- a/src/components/shared/Table/TableHeader.jsx
+++ b/src/components/shared/Table/TableHeader.jsx
@@ -1,0 +1,14 @@
+'use client'
+import { twMerge } from 'tailwind-merge';
+import { Filter } from '../Filter';
+
+const TableHeader = ({ children, className }) => {
+  return (
+    <th className={twMerge('w-full flex items-center', className)}>
+      {children}
+      <Filter size={20} />
+    </th>
+  );
+};
+
+export { TableHeader };

--- a/src/components/shared/Table/TableRoot.jsx
+++ b/src/components/shared/Table/TableRoot.jsx
@@ -1,6 +1,5 @@
-'use client';
 const TableRoot = ({ children }) => {
-  <table className="w-full">{children}</table>;
+  return <table className="w-full flex flex-col overflow-auto">{children}</table>;
 };
 
 export { TableRoot };

--- a/src/components/shared/Table/TableRoot.jsx
+++ b/src/components/shared/Table/TableRoot.jsx
@@ -1,0 +1,6 @@
+'use client';
+const TableRoot = ({ children }) => {
+  <table className="w-full">{children}</table>;
+};
+
+export { TableRoot };

--- a/src/components/shared/Table/TableRow.jsx
+++ b/src/components/shared/Table/TableRow.jsx
@@ -1,8 +1,7 @@
-'use client';
 import { twMerge } from 'tailwind-merge';
 
 const TableRow = ({ children, className }) => {
-  <tr className={twMerge('w-full flex', className)}>{children}</tr>;
+  return <tr className={twMerge('w-full flex', className)}>{children}</tr>;
 };
 
 export { TableRow };

--- a/src/components/shared/Table/TableRow.jsx
+++ b/src/components/shared/Table/TableRow.jsx
@@ -1,0 +1,8 @@
+'use client';
+import { twMerge } from 'tailwind-merge';
+
+const TableRow = ({ children, className }) => {
+  <tr className={twMerge('w-full flex', className)}>{children}</tr>;
+};
+
+export { TableRow };

--- a/src/components/shared/Table/index.js
+++ b/src/components/shared/Table/index.js
@@ -1,0 +1,7 @@
+import { TableRoot } from './TableRoot';
+
+const Table = {
+  Root: TableRoot,
+};
+
+export { Table };

--- a/src/components/shared/Table/index.js
+++ b/src/components/shared/Table/index.js
@@ -1,7 +1,13 @@
+import { TableCells } from './TableCells';
+import { TableHeader } from './TableHeader';
 import { TableRoot } from './TableRoot';
+import { TableRow } from './TableRow';
 
 const Table = {
   Root: TableRoot,
+  Row: TableRow,
+  Header: TableHeader,
+  Cells: TableCells,
 };
 
 export { Table };

--- a/src/components/shared/Title/Title.jsx
+++ b/src/components/shared/Title/Title.jsx
@@ -1,3 +1,4 @@
+'use client';
 import { twMerge } from 'tailwind-merge';
 import { themes, useTheme } from '@/contexts/ThemeContext';
 

--- a/src/locales/commons.js
+++ b/src/locales/commons.js
@@ -39,6 +39,14 @@ const commons = {
       label: 'candidate-se',
     },
   },
+  tableJobs:{
+    jobs: 'Vagas',
+    sector: 'Setor',
+    numberJobs: 'N° de Vagas',
+    initialDate: 'Data inicial',
+    finalDate: 'Data final',
+    details: 'Detalhes'
+  }
 };
 
 export { commons };

--- a/src/locales/commons.js
+++ b/src/locales/commons.js
@@ -39,14 +39,14 @@ const commons = {
       label: 'candidate-se',
     },
   },
-  tableJobs:{
+  tableJobs: {
     jobs: 'Vagas',
     sector: 'Setor',
     numberJobs: 'N° de Vagas',
     initialDate: 'Data inicial',
     finalDate: 'Data final',
-    details: 'Detalhes'
-  }
+    details: 'Detalhes',
+  },
 };
 
 export { commons };

--- a/src/locales/recruiter.js
+++ b/src/locales/recruiter.js
@@ -37,10 +37,11 @@ const recruiter = {
       },
     },
   },
-  jobs:{
+  jobs: {
     title: 'Vagas',
-    description: 'Nesse espaço você consegue visualizar, adicionar e deletar  vagas cadastradas na plataforma.'
-  }
+    description:
+      'Nesse espaço você consegue visualizar, adicionar e deletar  vagas cadastradas na plataforma.',
+  },
 };
 
 export { recruiter };

--- a/src/locales/recruiter.js
+++ b/src/locales/recruiter.js
@@ -37,6 +37,10 @@ const recruiter = {
       },
     },
   },
+  jobs:{
+    title: 'Vagas',
+    description: 'Nesse espaço você consegue visualizar, adicionar e deletar  vagas cadastradas na plataforma.'
+  }
 };
 
 export { recruiter };


### PR DESCRIPTION
## Purpose

Create screen jobs recruiter

## Approach and changes

Create a vacancy screen from the recruiter profile, create tables and components to compose the page and add corresponding texts.

## Definition of done

- [x] Behavior reviewed
- [x] Development completed
- [x] Reviewers assigned
- [x] Meets minimum browser support
- [x] Meets accessibility requirements
- [x] Documentation

## Issues

https://github.com/recrutaeu/recrutaeu-app/issues/15

## Figma

[_Link to the feature page. To get the specific page link, right click on page name > Copy/Paste > Copy link_
](https://www.figma.com/file/vstOy2LnnSxTRwnNTKce2k/recrutaeu?type=design&node-id=44-6796&mode=design&t=nlbq6qgFJ6yP8MqQ-0)

## Screenshots

![chrome-capture-2023-8-20](https://github.com/recrutaeu/recrutaeu-app/assets/48692940/9472b21a-edf8-46db-9733-a974db30692d)

